### PR TITLE
feat: MacOSX10.12.sdk.tar.xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 - [Mac OS X 10.15 (macOS Catalina)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.15)
 - [Mac OS X 10.14 (macOS Mojave)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.14)
 - [Mac OS X 10.13 (macOS High Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.13)
+- [Mac OS X 10.12 (macOS Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.12)
 
 All SDKs were packaged using **osxcross**. Check out [Packaging the SDK on macOS](https://github.com/tpoechtrager/osxcross#packaging-the-sdk) for more details.
 

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -127,5 +127,18 @@
         "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.13",
         "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.13/MacOSX10.13.sdk.tar.xz",
         "github_download_sha256sum": "9d3eddc34a510198694f5ec7cfbdebaee4c0c7ba68ad1d957cb566649c9a0f84"
+    },
+    {
+        "version": "macOS 10.12",
+        "name": "Sierra",
+        "darwin": "16.0.0",
+        "release_date": "2016-09-13",
+        "architectures": [
+            "x86",
+            "x86_64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.12",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.12/MacOSX10.12.sdk.tar.xz",
+        "github_download_sha256sum": "53f552170d0789bef2cd6d3dfa8f710b84843d7601175f041f302618b51d5a13"
     }
 ]


### PR DESCRIPTION
Initial download of SDK can be found at https://www.mediafire.com/file/5kva9b04u79dk4i/MacOSX10.12.sdk.tar.xz/file