### PR TITLE
feat: MacOSX10.11.sdk.tar.xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 - [Mac OS X 10.14 (macOS Mojave)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.14)
 - [Mac OS X 10.13 (macOS High Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.13)
 - [Mac OS X 10.12 (macOS Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.12)
+- [Mac OS X 10.11 (OS X El Capitan)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.11)
 
 All SDKs were packaged using **osxcross**. Check out [Packaging the SDK on macOS](https://github.com/tpoechtrager/osxcross#packaging-the-sdk) for more details.
 

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -140,5 +140,18 @@
         "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.12",
         "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.12/MacOSX10.12.sdk.tar.xz",
         "github_download_sha256sum": "53f552170d0789bef2cd6d3dfa8f710b84843d7601175f041f302618b51d5a13"
+    },
+    {
+        "version": "OS X 10.11",
+        "name": "El Capitan",
+        "darwin": "15.0.0",
+        "release_date": "2015-09-16",
+        "architectures": [
+            "x86",
+            "x86_64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.11",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.12/MacOSX10.11.sdk.tar.xz",
+        "github_download_sha256sum": "994b7a737a9f5e797af62463e1d540fca99e33b4c1448ad11ba1548424d26807"
     }
 ]


### PR DESCRIPTION
Initial download of SDK can be found at https://www.mediafire.com/file/h7aj3s0cjyc6lh7/MacOSX10.11.sdk.tar.xz/file

Relates to #2 