### PR TITLE
feat: MacOSX10.10.sdk.tar.xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 - [Mac OS X 10.13 (macOS High Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.13)
 - [Mac OS X 10.12 (macOS Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.12)
 - [Mac OS X 10.11 (OS X El Capitan)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.11)
+- [Mac OS X 10.10 (OS X Yosemite)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.10)
 
 All SDKs were packaged using **osxcross**. Check out [Packaging the SDK on macOS](https://github.com/tpoechtrager/osxcross#packaging-the-sdk) for more details.
 

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -153,5 +153,18 @@
         "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.11",
         "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.11/MacOSX10.11.sdk.tar.xz",
         "github_download_sha256sum": "994b7a737a9f5e797af62463e1d540fca99e33b4c1448ad11ba1548424d26807"
+    },
+    {
+        "version": "OS X 10.10",
+        "name": "Yosemite",
+        "darwin": "14.0.0",
+        "release_date": "2014-10-16",
+        "architectures": [
+            "x86",
+            "x86_64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.10",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.10/MacOSX10.10.sdk.tar.xz",
+        "github_download_sha256sum": "bfc056a5ad80403d72d7a50319bdd106545ea5936af2c343a517f96bdec4caee"
     }
 ]


### PR DESCRIPTION
Initial download of SDK can be found at https://www.mediafire.com/file/65amwus6fv07ml2/MacOSX10.10.sdk.tar.xz/file

Relates to #2