### PR TITLE
feat: MacOSX10.9.sdk.tar.xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 - [Mac OS X 10.12 (macOS Sierra)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.12)
 - [Mac OS X 10.11 (OS X El Capitan)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.11)
 - [Mac OS X 10.10 (OS X Yosemite)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.10)
+- [Mac OS X 10.9 (OS X Mavericks)](https://github.com/joseluisq/macosx-sdks/releases/tag/10.9)
 
 All SDKs were packaged using **osxcross**. Check out [Packaging the SDK on macOS](https://github.com/tpoechtrager/osxcross#packaging-the-sdk) for more details.
 

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -166,5 +166,18 @@
         "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.10",
         "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.10/MacOSX10.10.sdk.tar.xz",
         "github_download_sha256sum": "bfc056a5ad80403d72d7a50319bdd106545ea5936af2c343a517f96bdec4caee"
+    },
+    {
+        "version": "OS X 10.9",
+        "name": "Mavericks",
+        "darwin": "13.0.0",
+        "release_date": "2013-10-22",
+        "architectures": [
+            "x86",
+            "x86_64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/10.9",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/10.9/MacOSX10.9.sdk.tar.xz",
+        "github_download_sha256sum": "6e1dc54e46bb1397b9db7194933475aae9c2df1267a4d20f6d0a8dfff72c3b03"
     }
 ]


### PR DESCRIPTION
Initial download of SDK can be found at https://www.mediafire.com/file/m3iqccuyxgs09hh/MacOSX10.9.sdk.tar.xz/file

Relates to #2