### PR TITLE
feat: MacOSX26.0.sdk.tar.xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 
 ## SDKs
 
+- [Mac OS X 26.0 (macOS Tahoe)](https://github.com/joseluisq/macosx-sdks/releases/tag/26.0)
 - [Mac OS X 15.5 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.5)
 - [Mac OS X 15.4 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.4)
 - [Mac OS X 15.2 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.2)

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -1,5 +1,18 @@
 [
     {
+        "version": "macOS 26.0",
+        "name": "Tahoe",
+        "darwin": "26.0.0",
+        "release_date": "2025-09-15",
+        "architectures": [
+            "x86_64",
+            "arm64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/26.0",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/26.0/MacOSX26.0.sdk.tar.xz",
+        "github_download_sha256sum": "07ccaa2891454713c3a230dd87283f76124193309d9a7617ebee45354c9302d2"
+    },
+    {
         "version": "macOS 15.5",
         "name": "Sequoia",
         "darwin": "24.5.0",


### PR DESCRIPTION
Add `MacOSX26.0.sdk.tar.xz`  
- Download: https://github.com/socheatsok78/macos-sdks/releases/download/rolling/MacOSX26.0.sdk.tar.xz
- SHA256SUM: `07ccaa2891454713c3a230dd87283f76124193309d9a7617ebee45354c9302d2`