### PR TITLE
feat: MacOSX26.0.tar.xz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+# [26.0](https://github.com/joseluisq/macosx-sdks/releases/tag/26.0) - Oct 15, 2025
+
+[macOS Sequoia 15.5](https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes) SDK packaged using [osxcross](https://github.com/tpoechtrager/osxcross#packaging-the-sdk).
+
+**SHA256SUM:** `04a3037dbf5bd2a0bb208c6ba4fe8a3873753c8e399222d4856404ce54413206`
+
+__Note:__
+
+Please ensure you have read and understood the [Xcode license terms](https://www.apple.com/legal/sla/docs/xcode.pdf) first.
+
 # [15.5](https://github.com/joseluisq/macosx-sdks/releases/tag/15.5) - Jun 14, 2025
 
 [macOS Sequoia 15.5](https://developer.apple.com/documentation/macos-release-notes/macos-15_5-release-notes) SDK packaged using [osxcross](https://github.com/tpoechtrager/osxcross#packaging-the-sdk).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Please ensure you have read and understood first the [Xcode license terms](https
 
 ## SDKs
 
+- [Mac OS X 15.5 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/26.0)
 - [Mac OS X 15.5 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.5)
 - [Mac OS X 15.4 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.4)
 - [Mac OS X 15.2 (macOS Sequoia)](https://github.com/joseluisq/macosx-sdks/releases/tag/15.2)

--- a/macosx_sdks.json
+++ b/macosx_sdks.json
@@ -1,5 +1,18 @@
 [
     {
+        "version": "macOS 26.0",
+        "name": "Tahoe",
+        "darwin": "26.0",
+        "release_date": "2025-05-12",
+        "architectures": [
+            "x86_64",
+            "arm64"
+        ],
+        "github_release": "https://github.com/joseluisq/macosx-sdks/releases/tag/26.0",
+        "github_download_url": "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX26.0.sdk.tar.xz",
+        "github_download_sha256sum": "04a3037dbf5bd2a0bb208c6ba4fe8a3873753c8e399222d4856404ce54413206"
+    },
+    {
         "version": "macOS 15.5",
         "name": "Sequoia",
         "darwin": "24.5.0",


### PR DESCRIPTION
Release with binary and SHA256Sum available here:

https://github.com/deriamis/macosx-sdks/releases/tag/26.0